### PR TITLE
Fix: fix type error of samp in test_bootstrap

### DIFF
--- a/tests/statistics/test_Bootstrap.py
+++ b/tests/statistics/test_Bootstrap.py
@@ -37,6 +37,7 @@ def Test_Bootstrap():
 
     # Test that the bootstrap distribution is reasonable
     normalCDF = sp.stats.norm(loc=REFm,scale=REFe).cdf
+    samp = np.array(samp)
     if KSTest_1side(samp,normalCDF) < 0.05:
         lpass = False
         logger.TBFail('Significant KS tension')


### PR DESCRIPTION
## Description

Fixes a type error in `test_bootstrap.py` when calling `KSTest_1side`.  
The function expects an input of type `numpy.ndarray`, but `samp` was passed as a `list`.  
Converted `samp` to `numpy.ndarray` using `np.array()`, which resolves the issue.

### Steps to Reproduce
- Run `python3  test_bootstrap.py`
- Observe the error: `latqcdtools.base.logger.ToolboxException: KSTest_1side: Expected type <class 'numpy.ndarray'> for data but received <class 'list'>`

### Changes
- Updated `samp` conversion in `test_bootstrap.py` before passing to `KSTest_1side`.

### Why
This ensures the input type matches the function requirement and prevents runtime errors.
